### PR TITLE
Disable [DEBUG-DPH] logs by default

### DIFF
--- a/src/main/java/com/nemonicorp/orbs/DpsCalculator.java
+++ b/src/main/java/com/nemonicorp/orbs/DpsCalculator.java
@@ -34,10 +34,12 @@ public class DpsCalculator {
                                    ModifierEngine engine) {
         if (tier < 1) return -1;
         if (!isWeapon(item, nbt)) {
-            NemonicOrbPlugin.getInstance().getLogger().info(
-                    "[DEBUG-DPH] isWeapon=false material=" + item.getType().name()
-                    + " hasType=" + nbt.hasType()
-                    + " mmoType=" + nbt.getString("MMOITEMS_ITEM_TYPE"));
+            if (NemonicOrbPlugin.getInstance().getConfig().getBoolean("debug-dph", false)) {
+                NemonicOrbPlugin.getInstance().getLogger().info(
+                        "[DEBUG-DPH] isWeapon=false material=" + item.getType().name()
+                        + " hasType=" + nbt.hasType()
+                        + " mmoType=" + nbt.getString("MMOITEMS_ITEM_TYPE"));
+            }
             return -1;
         }
 

--- a/src/main/java/com/nemonicorp/orbs/OrbListener.java
+++ b/src/main/java/com/nemonicorp/orbs/OrbListener.java
@@ -1173,7 +1173,7 @@ public class OrbListener implements Listener {
 
         // DPH (apenas para armas tier >= 1)
         double dps = DpsCalculator.calculate(item, nbt, mods, tier, false, engine);
-        if (debug()) plugin.getLogger().info("[DEBUG-DPH] vanilla tier=" + tier
+        if (plugin.getConfig().getBoolean("debug-dph", false)) plugin.getLogger().info("[DEBUG-DPH] vanilla tier=" + tier
                 + " material=" + item.getType().name() + " dps=" + dps);
         if (dps >= 0) {
             lore.add(cc(""));


### PR DESCRIPTION
DpsCalculator e OrbListener tinham logs [DEBUG-DPH] disparando em todo render de tooltip de arma. O log do DpsCalculator era incondicional (sem checar debug flag).

Agora ambos respeitam a flag 'debug-dph' do config.yml (default false). Para reativar (em troubleshooting), adicionar 'debug-dph: true' ao config.yml e fazer reload.